### PR TITLE
Add health data disclosure to Roxie privacy policy

### DIFF
--- a/roxie.html
+++ b/roxie.html
@@ -42,6 +42,55 @@
       request will be retained by us and used as described in this privacy
       policy.
     </p>
+    <p><strong>Health and Fitness Data</strong></p>
+    <p>
+      Our app collects and uses the following health and fitness related data
+      that you provide directly through the app. This data is not collected
+      automatically from device sensors; it is entered by you during onboarding
+      and workout logging.
+    </p>
+    <p>The health and fitness data we collect includes:</p>
+    <ul>
+      <li>
+        <strong>Personal profile information:</strong> gender, date of birth,
+        and fitness level
+      </li>
+      <li>
+        <strong>Fitness goals and preferences:</strong> exercise types, workout
+        goals, available schedule, and workout location
+      </li>
+      <li>
+        <strong>Pre-workout condition data:</strong> fatigue level, muscle
+        soreness, stress level, and sleep quality (Hooper Index, rated 1–7)
+      </li>
+      <li>
+        <strong>Post-workout condition data:</strong> session rating of
+        perceived exertion (RPE, rated 1–10) and workout duration
+      </li>
+      <li>
+        <strong>Weight training records:</strong> exercise name, sets,
+        repetitions, and rest time
+      </li>
+      <li>
+        <strong>Running workout records:</strong> distance, pace, and time
+      </li>
+    </ul>
+    <p><strong>Purpose of Health Data Collection</strong></p>
+    <p>
+      We collect and use your health and fitness data solely for the following
+      purposes:
+    </p>
+    <ul>
+      <li>To generate personalized workout plans tailored to your goals and fitness level</li>
+      <li>To track your workout performance and physical condition over time</li>
+      <li>To adjust and optimize your training programs based on your recorded data</li>
+    </ul>
+    <p>
+      Your health and fitness data is stored securely and is not sold, shared
+      with, or disclosed to any third parties for advertising or marketing
+      purposes. This data is used exclusively within the app to provide and
+      improve the Service for you.
+    </p>
     <div>
       <p>
         The app does use third-party services that may collect information used


### PR DESCRIPTION
## Summary
Added comprehensive health and fitness data disclosure section to Roxie's privacy policy to comply with Google Play's User Data policy requirements.

## Changes
- Added "Health and Fitness Data" section detailing all collected health data (fitness profile, pre/post-workout conditions, training records)
- Added "Purpose of Health Data Collection" section explaining data usage for personalized workouts and performance tracking
- Clarified that health data is user-provided, not automatically collected from device sensors
- Stated that health data is not shared with third parties

## Context
Google Play rejected the app because the privacy policy did not disclose Health Data collection. This change addresses that specific requirement.