### PR TITLE
add deskly

### DIFF
--- a/deskly-term.html
+++ b/deskly-term.html
@@ -1,0 +1,159 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Terms &amp; Conditions</title>
+    <style>
+      body {
+        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        padding: 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <strong>Terms &amp; Conditions</strong>
+    <p>
+      By downloading or using the app, these terms will automatically apply to
+      you – you should make sure therefore that you read them carefully before
+      using the app. You're not allowed to copy or modify the app, any part of
+      the app, or our trademarks in any way. You're not allowed to attempt to
+      extract the source code of the app, and you also shouldn't try to
+      translate the app into other languages or make derivative versions. The
+      app itself, and all the trademarks, copyright, database rights, and other
+      intellectual property rights related to it, still belong to Mission
+      fingers.
+    </p>
+    <p>
+      Mission fingers is committed to ensuring that the app is as useful and
+      efficient as possible. For that reason, we reserve the right to make
+      changes to the app or to charge for its services, at any time and for any
+      reason. We will never charge you for the app or its services without
+      making it very clear to you exactly what you're paying for.
+    </p>
+    <p>
+      The Deskly app processes posture-related data locally on your device to
+      provide our Service. It's your responsibility to keep your phone, Apple
+      Watch, and access to the app secure. We therefore recommend that you do
+      not jailbreak your device, which is the process of removing software
+      restrictions and limitations imposed by the official operating system of
+      your device. It could make your device vulnerable to
+      malware/viruses/malicious programs, compromise your device's security
+      features, and it could mean that the Deskly app won't work properly or
+      at all.
+    </p>
+    <p><strong>Intended Use and Medical Disclaimer</strong></p>
+    <p>
+      Deskly is a posture awareness and habit-building tool. It is not a
+      medical device, and it does not diagnose, treat, cure, or prevent any
+      medical condition. Feedback from the app, including face-distance
+      measurements and posture alerts, is approximate and is intended to help
+      you build better desk habits. If you have any medical concern related to
+      posture, neck, back, or vision, consult a qualified healthcare
+      professional. You are responsible for using the app safely and for
+      taking breaks from your screen as appropriate.
+    </p>
+    <p><strong>Camera and HealthKit</strong></p>
+    <p>
+      Deskly requires access to the front-facing camera to measure the
+      distance between your face and the screen, and (on supported devices)
+      to HealthKit in order to keep an Apple Watch workout session active for
+      reliable haptic alerts. You can grant or revoke these permissions at any
+      time in the Settings app. If permissions are revoked, some features of
+      the app may not function. The camera is used only while a posture
+      session is running; no video or images are recorded or transmitted.
+    </p>
+    <div>
+      <p>
+        The app relies on Apple platform services that declare their own Terms
+        and Conditions.
+      </p>
+      <p>
+        Link to Terms and Conditions of platform services used by the app:
+      </p>
+      <ul>
+        <li>
+          <a
+            href="https://www.apple.com/legal/internet-services/itunes/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Apple Media Services Terms and Conditions</a
+          >
+        </li>
+      </ul>
+    </div>
+    <p>
+      You should be aware that there are certain things that Mission fingers
+      will not take responsibility for. Certain functions of the app may
+      require an active internet connection (for example, to receive updates
+      through the App Store). The connection can be Wi-Fi or provided by your
+      mobile network provider, but Mission fingers cannot take responsibility
+      for the app not working at full functionality if you don't have access
+      to Wi-Fi, and you don't have any of your data allowance left.
+    </p>
+    <p>
+      If you're using the app outside of an area with Wi-Fi, you should
+      remember that the terms of the agreement with your mobile network
+      provider will still apply. As a result, you may be charged by your
+      mobile provider for the cost of data for the duration of the connection
+      while accessing the app, or other third-party charges. In using the
+      app, you're accepting responsibility for any such charges, including
+      roaming data charges if you use the app outside of your home territory
+      (i.e. region or country) without turning off data roaming. If you are
+      not the bill payer for the device on which you're using the app, please
+      be aware that we assume that you have received permission from the bill
+      payer for using the app.
+    </p>
+    <p>
+      Along the same lines, Mission fingers cannot always take responsibility
+      for the way you use the app i.e. You need to make sure that your device
+      stays charged – if it runs out of battery and you can't turn it on to
+      avail the Service, Mission fingers cannot accept responsibility.
+    </p>
+    <p>
+      With respect to Mission fingers's responsibility for your use of the
+      app, when you're using the app, it's important to bear in mind that
+      although we endeavor to ensure that it is updated and correct at all
+      times, posture detection is approximate and depends on lighting, camera
+      position, and other environmental conditions. Mission fingers accepts no
+      liability for any loss, direct or indirect, you experience as a result
+      of relying wholly on this functionality of the app.
+    </p>
+    <p>
+      At some point, we may wish to update the app. The app is currently
+      available on iOS and watchOS – the requirements for these systems (and
+      for any additional systems we decide to extend the availability of the
+      app to) may change, and you'll need to download the updates if you want
+      to keep using the app. Mission fingers does not promise that it will
+      always update the app so that it is relevant to you and/or works with
+      the iOS or watchOS version that you have installed on your device.
+      However, you promise to always accept updates to the application when
+      offered to you. We may also wish to stop providing the app, and may
+      terminate use of it at any time without giving notice of termination to
+      you. Unless we tell you otherwise, upon any termination, (a) the rights
+      and licenses granted to you in these terms will end; (b) you must stop
+      using the app, and (if needed) delete it from your device.
+    </p>
+    <p><strong>Changes to This Terms and Conditions</strong></p>
+    <p>
+      We may update our Terms and Conditions from time to time. Thus, you are
+      advised to review this page periodically for any changes. We will notify
+      you of any changes by posting the new Terms and Conditions on this page.
+    </p>
+    <p>These terms and conditions are effective as of 2026-05-22</p>
+    <p><strong>Contact Us</strong></p>
+    <p>
+      If you have any questions or suggestions about our Terms and Conditions,
+      do not hesitate to contact us at young@missionfingers.com.
+    </p>
+    <p>
+      This Terms and Conditions page was generated by
+      <a
+        href="https://app-privacy-policy-generator.nisrulz.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        >App Privacy Policy Generator</a
+      >
+    </p>
+  </body>
+</html>

--- a/deskly.html
+++ b/deskly.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>Privacy Policy</title>
+    <style>
+      body {
+        font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        padding: 1em;
+      }
+    </style>
+  </head>
+  <body>
+    <strong>Privacy Policy</strong>
+    <p>
+      Mission fingers built the Deskly app as a Commercial app. This SERVICE is
+      provided by Mission fingers and is intended for use as is.
+    </p>
+    <p>
+      This page is used to inform visitors regarding our policies with the
+      collection, use, and disclosure of Personal Information if anyone decided
+      to use our Service.
+    </p>
+    <p>
+      If you choose to use our Service, then you agree to the collection and use
+      of information in relation to this policy. The Personal Information that
+      we collect is used for providing and improving the Service. We will not
+      use or share your information with anyone except as described in this
+      Privacy Policy.
+    </p>
+    <p>
+      The terms used in this Privacy Policy have the same meanings as in our
+      Terms and Conditions, which are accessible at Deskly unless otherwise
+      defined in this Privacy Policy.
+    </p>
+    <p><strong>Information Collection and Use</strong></p>
+    <p>
+      Deskly is designed to run entirely on your device. We do not require an
+      account, and we do not collect, store, or transmit personally identifiable
+      information to our servers. All preferences, calibration data, and
+      session records remain on your device.
+    </p>
+    <p><strong>Camera (Face Distance Tracking)</strong></p>
+    <p>
+      Deskly uses your device's front-facing camera together with Apple's
+      ARKit to estimate the distance between your face and the screen. This
+      measurement is used solely to detect poor desk posture (for example,
+      slouching closer to the screen) and to deliver real-time feedback.
+    </p>
+    <ul>
+      <li>
+        <strong>Video is never recorded.</strong> The camera feed is processed
+        in memory only, and no frames or images are saved to your device.
+      </li>
+      <li>
+        <strong>Video is never transmitted.</strong> No camera data leaves your
+        device, and no images, video, or biometric identifiers are sent to us
+        or to any third party.
+      </li>
+      <li>
+        <strong>No facial recognition.</strong> We do not identify you, build a
+        face print, or otherwise use the camera for identification purposes.
+      </li>
+      <li>
+        The camera runs only while a posture session is active and is paused
+        or stopped according to the session state and device power conditions.
+      </li>
+    </ul>
+    <p><strong>HealthKit</strong></p>
+    <p>
+      Deskly integrates with Apple's HealthKit framework on iPhone and Apple
+      Watch for the following technical purposes:
+    </p>
+    <ul>
+      <li>
+        To start an Apple Watch workout session so that the Watch app can stay
+        active in the background during a posture session and deliver reliable
+        haptic alerts on your wrist.
+      </li>
+      <li>
+        To record the posture session as a workout in the Health app so that
+        notifications and vibrations remain stable for the duration of the
+        session.
+      </li>
+    </ul>
+    <p>
+      Health and fitness data managed by HealthKit stays on your device under
+      Apple's Health framework. Deskly does not export your HealthKit data,
+      and we do not transmit HealthKit information to our servers or to any
+      third party. You can review and revoke Deskly's HealthKit permissions at
+      any time in the Settings app under Privacy &amp; Security &gt; Health.
+    </p>
+    <p><strong>On-Device Data</strong></p>
+    <p>
+      The following data is created and stored locally on your device only:
+    </p>
+    <ul>
+      <li>
+        <strong>Posture calibration:</strong> the reference face distance you
+        set for your desk setup.
+      </li>
+      <li>
+        <strong>Session data:</strong> start time, duration, and basic
+        statistics of each posture session, used to show you progress within
+        the app.
+      </li>
+      <li>
+        <strong>App preferences:</strong> sensitivity, notification, and
+        Watch-related settings.
+      </li>
+    </ul>
+    <p>
+      You can remove all of this data at any time by uninstalling the app from
+      your device.
+    </p>
+    <p><strong>Third-Party Services</strong></p>
+    <p>
+      Deskly does not integrate any third-party analytics, advertising, or
+      tracking SDKs. The app communicates only with Apple platform services
+      (ARKit, HealthKit, WatchConnectivity, and the App Store / StoreKit when
+      applicable) that are part of iOS and watchOS. Your use of those Apple
+      services is governed by Apple's policies.
+    </p>
+    <ul>
+      <li>
+        <a
+          href="https://www.apple.com/legal/privacy/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Apple Privacy Policy</a
+        >
+      </li>
+    </ul>
+    <p><strong>Log Data</strong></p>
+    <p>
+      Deskly does not operate a backend service that collects log data. In the
+      event that you contact us directly (for example, by email), any
+      information you choose to send us (such as a description of an issue or
+      diagnostic details copied from your device) will be used only to respond
+      to your request and will not be shared with third parties.
+    </p>
+    <p><strong>Cookies</strong></p>
+    <p>
+      Deskly is a native iOS and watchOS application and does not use cookies.
+    </p>
+    <p><strong>Security</strong></p>
+    <p>
+      Because Deskly keeps your data on your device and relies on Apple's
+      platform protections (such as the Secure Enclave, app sandboxing, and
+      HealthKit's permission model), your information benefits from the same
+      security guarantees as the rest of your iPhone and Apple Watch. No
+      method of electronic storage is 100% secure, however, and we cannot
+      guarantee absolute security.
+    </p>
+    <p><strong>Links to Other Sites</strong></p>
+    <p>
+      This Service may contain links to other sites. If you tap a third-party
+      link, you will be directed to that site. Note that these external sites
+      are not operated by us. Therefore, we strongly advise you to review the
+      Privacy Policy of these websites. We have no control over and assume no
+      responsibility for the content, privacy policies, or practices of any
+      third-party sites or services.
+    </p>
+    <p><strong>Children's Privacy</strong></p>
+    <div>
+      <p>
+        These Services do not address anyone under the age of 13. We do not
+        knowingly collect personally identifiable information from children
+        under 13 years of age. Because Deskly does not transmit personal data
+        off-device, no such information is sent to our servers. If you are a
+        parent or guardian and you are aware that your child has provided us
+        with personal information, please contact us so that we will be able
+        to do the necessary actions.
+      </p>
+    </div>
+    <p><strong>Changes to This Privacy Policy</strong></p>
+    <p>
+      We may update our Privacy Policy from time to time. Thus, you are advised
+      to review this page periodically for any changes. We will notify you of
+      any changes by posting the new Privacy Policy on this page.
+    </p>
+    <p>This policy is effective as of 2026-05-22</p>
+    <p><strong>Contact Us</strong></p>
+    <p>
+      If you have any questions or suggestions about our Privacy Policy, do not
+      hesitate to contact us at young@missionfingers.com.
+    </p>
+    <p>
+      This privacy policy page was created at
+      <a
+        href="https://privacypolicytemplate.net"
+        target="_blank"
+        rel="noopener noreferrer"
+        >privacypolicytemplate.net </a
+      >and modified/generated by
+      <a
+        href="https://app-privacy-policy-generator.nisrulz.com/"
+        target="_blank"
+        rel="noopener noreferrer"
+        >App Privacy Policy Generator</a
+      >
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add Privacy Policy (`deskly.html`) and Terms & Conditions (`deskly-term.html`) for Deskly.
- Adapted from the roxie template, tailored to Deskly's actual data handling per the Posture iOS/watchOS codebase:
  - Camera (ARKit face-distance only — video never recorded or transmitted).
  - HealthKit (Apple Watch workout session to keep haptic alerts reliable).
  - No third-party SDKs (no RevenueCat / Firebase / analytics).
- Added a posture-specific medical disclaimer in the Terms.

## Test plan
- [ ] Open `https://byyoungjin.github.io/privacyPolicy/deskly.html` after deploy and verify content renders.
- [ ] Open `https://byyoungjin.github.io/privacyPolicy/deskly-term.html` after deploy and verify content renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)